### PR TITLE
Fix a example code in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,8 +108,8 @@ Example
     class SampleViewModel(ObservableObject):
         num = published('num')
 
-        def __init__(self, bot):
-            super().__init__(bot)
+        def __init__(self):
+            super().__init__()
             self.num = 0
 
         def countup(self):
@@ -122,7 +122,7 @@ Example
     class SampleView(View):
         def __init__(self, bot):
             super().__init__(bot)
-            self.view_model = SampleViewModel(bot)
+            self.view_model = SampleViewModel()
 
         async def add_reaction(self):
             await self.get_message().add_reaction("\U0001f44d")


### PR DESCRIPTION
軽微なエラー修正です。

過去の破壊的変更の影響で、README上の example を実行すると以下のエラーが発生します。

```py
Ignoring exception in on_message
Traceback (most recent call last):
  File "C:\Users\(username)\.virtualenvs\tester-saFxrxCN\lib\site-packages\discord\client.py", line 331, in _run_event
    await coro(*args, **kwargs)
  File "c:\Users\(username)\Documents\Programs\Python\discord-ext-ui-fork\tester\main.py", line 50, in on_message
    await SampleView(client).start(message.channel)
  File "c:\Users\(username)\Documents\Programs\Python\discord-ext-ui-fork\tester\main.py", line 24, in __init__
    self.view_model = SampleViewModel(bot)
  File "c:\Users\(username)\Documents\Programs\Python\discord-ext-ui-fork\tester\main.py", line 11, in __init__
    super().__init__(bot)
TypeError: __init__() takes 1 positional argument but 2 were given
```

このエラーを解消するために、引数を修正しました。
修正したものを実行したところ、 `TypeError` は消えましたが、これで問題ないでしょうか。