### PR TITLE
Fix View.build

### DIFF
--- a/discord/ext/ui/view.py
+++ b/discord/ext/ui/view.py
@@ -28,10 +28,15 @@ class View(ui.View):
         pass
 
     def build(self) -> BuildResponse:
-        return dict(
+        build_response = dict(
             content=self._view_message.content,
-            embed=self._view_message.embed,
             view=self
+        )
+        if self._view_message.embed is None:
+            return build_response
+        return dict(
+            embed=self._view_message.embed,
+            **build_response
         )
 
     @property


### PR DESCRIPTION
#16 に対するプルリクエストです

`InteractionResponse.send_message`で`View.build`を使えるようにします。
`.send_message`は埋め込みを使用しない場合、`embed`引数に`discord.utils.MISSING`を渡さなければいけないのですが、`None`が渡されたため、エラーが発生したようです。
ただ、`MISSING`を返すと`TextChannel.send`で使用できなくなるので、`self._view_message.embed`が`None`だった時には`embed`を返さないようにしました。