### PR TITLE
Add 'sync' to 'ViewTracker'

### DIFF
--- a/discord/ext/ui/custom.py
+++ b/discord/ext/ui/custom.py
@@ -31,9 +31,12 @@ class CustomButton(ui.Button):
             if not self.check_func(interaction):
                 return
         if self.modal_submit is not None:
+            self.modal_submit.view = self.view
             await interaction.response.send_modal(self.modal_submit)
             return
         await _call_any(self.callback_func, interaction)
+        if self.view.sync:
+            await self.view.update()
 
 
 class CustomSelect(ui.Select):
@@ -77,3 +80,5 @@ class CustomSelect(ui.Select):
                     selected_options.append(option)
                     continue
         await _call_any(self.callback_func, interaction, selected_options)
+        if self.view.sync:
+            await self.view.update()

--- a/discord/ext/ui/modal.py
+++ b/discord/ext/ui/modal.py
@@ -13,6 +13,7 @@ class Modal(ui.Modal):
         for component in components:
             self.add_item(component)
 
+        self.view = None
         self._hook = None
 
     def hook(self, func: Callable[[discord.Interaction], Any]) -> Modal:
@@ -22,5 +23,7 @@ class Modal(ui.Modal):
     async def on_submit(self, interaction: discord.Interaction) -> None:
         if self._hook is not None:
             await _call_any(self._hook, interaction)
+        if self.view.sync:
+            await self.view.update()
         if not interaction.response.is_done():
             await interaction.response.defer()

--- a/discord/ext/ui/tracker.py
+++ b/discord/ext/ui/tracker.py
@@ -11,9 +11,10 @@ from .message import Message
 
 
 class ViewTracker(ui.View):
-    def __init__(self, view: View, timeout: Optional[float] = 180.0):
+    def __init__(self, view: View, timeout: Optional[float] = 180.0, sync: bool = False):
         super().__init__(timeout=timeout)
         self.view: View = view
+        self.sync: bool = sync
         self.items: dict[str, str] = {}
         self.body: Optional[Message] = None
         self.message: Optional[discord.Message] = None


### PR DESCRIPTION
## 変更内容
`ViewTracker` に `sync` 引数を追加しました。

`Button` `Select` `Modal` の送信時に自動で `View` を更新します。

従来は監視している変数が更新された際に `View` を更新しますが、
基本的にそれはユーザーの操作に起因するもののため、これを作りました。

よろしくお願いします。